### PR TITLE
pyrsia_node_maven_build_service.bats disabled until 0.3

### DIFF
--- a/.github/workflows/run-bats-tests.yml
+++ b/.github/workflows/run-bats-tests.yml
@@ -1,19 +1,22 @@
 name: Integration Tests
 
 on:
+  schedule:
+    # scheduled at 3PM and 3AM daily
+    - cron: '0 3,15 * * *'
   pull_request:
     types:
       - opened
+      - closed
+      - synchronized
       - reopened
-  schedule:
-    # the tests scheduled at 3PM every day
-    - cron: '0 3,15 * * *'
+      - ready_for_review
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  run-tests:
+  run-integration-tests:
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/bats/tests/common-setup.bash
+++ b/bats/tests/common-setup.bash
@@ -26,11 +26,11 @@ _common_setup_file() {
 
   echo "Building the Pyrsia CLI sources, it might take a while..." >&3
   echo "Pyrsia CLI source dir: $PYRSIA_TEMP_DIR" >&3
-  cargo build --profile=release --package=pyrsia_cli --manifest-path=$PYRSIA_TEMP_DIR/Cargo.toml >&3
+  cargo build -q --profile=release --package=pyrsia_cli --manifest-path=$PYRSIA_TEMP_DIR/Cargo.toml
   echo "Building Pyrsia CLI completed!" >&3
   echo "Building the Pyrsia node docker image and starting the container, it might take a while..." >&3
   DOCKER_COMPOSE_PATH=$1;
-  docker-compose -f "$DOCKER_COMPOSE_PATH" up -d >&3
+  docker-compose -f "$DOCKER_COMPOSE_PATH" up -d
   sleep 10
   # check periodically if the node is up (using pyrsia ping)
   # shellcheck disable=SC2034
@@ -57,10 +57,10 @@ _common_teardown_file() {
   if [ "$CLEAN_UP_TEST_ENVIRONMENT" = true ]; then
     echo "Tearing down the tests environment..." >&3
     echo "Cleaning up the docker images and containers..."  >&3
-    docker-compose -f "$DOCKER_COMPOSE_PATH" down --rmi all >&3
+    docker-compose -f "$DOCKER_COMPOSE_PATH" down --rmi all
   else
     echo "Stopping the docker containers..." >&3
-    docker-compose -f "$DOCKER_COMPOSE_PATH" stop >&3
+    docker-compose -f "$DOCKER_COMPOSE_PATH" stop
     echo "WARNING: The docker images/container was not removed because 'CLEAN_UP_TEST_ENVIRONMENT'=FALSE'"  >&3
   fi
   echo "Done tearing the tests environment!" >&3

--- a/bats/tests/common-setup.bash
+++ b/bats/tests/common-setup.bash
@@ -24,8 +24,7 @@ _common_setup_file() {
     git clone --branch $git_branch $git_repo $PYRSIA_TEMP_DIR
   fi
 
-  echo "Building the Pyrsia CLI sources, it might take a while..." >&3
-  echo "Pyrsia CLI source dir: $PYRSIA_TEMP_DIR" >&3
+  echo "Building the Pyrsia CLI sources (Pyrsia CLI source dir: $PYRSIA_TEMP_DIR), it might take a while..." >&3
   cargo build -q --profile=release --package=pyrsia_cli --manifest-path=$PYRSIA_TEMP_DIR/Cargo.toml
   echo "Building Pyrsia CLI completed!" >&3
   echo "Building the Pyrsia node docker image and starting the container, it might take a while..." >&3

--- a/bats/tests/pyrsia_node_maven_build_service.bats_
+++ b/bats/tests/pyrsia_node_maven_build_service.bats_
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# TODO This test is disabled for now, more info in https://github.com/pyrsia/pyrsia/issues/1140
+
 # common setup
 COMMON_SETUP='common-setup'
 # docker compose file

--- a/bats/tests/resources/docker/Dockerfile
+++ b/bats/tests/resources/docker/Dockerfile
@@ -4,14 +4,14 @@ FROM rust:1.62-buster AS node_with_build_service
 WORKDIR /src
 ENV RUST_BACKTRACE=1
 ENV DEV_MODE=onapt
-RUN apt-get update && apt-get install -y
-RUN apt-get install build-essential libssl-dev cmake pkg-config jq openjdk-11-jdk maven jq -y
+RUN apt-get update && apt-get install -y -q
+RUN apt-get install build-essential libssl-dev cmake pkg-config jq openjdk-11-jdk maven jq -y -q
 RUN git clone https://github.com/tiainen/pyrsia_build_pipeline_prototype.git
 WORKDIR /src/pyrsia_build_pipeline_prototype
-RUN PATH="$HOME/.cargo/bin:$PATH" RUST_LOG=debug cargo build --workspace
+RUN PATH="$HOME/.cargo/bin:$PATH" RUST_LOG=debug cargo build -q --workspace
 WORKDIR /src
 COPY entrypoint_bootstrap_node.sh entrypoint_no_bootstrap_node.sh entrypoint_auth_node.sh ./
 RUN chmod +x ./*.sh
 RUN git clone https://github.com/pyrsia/pyrsia.git
 WORKDIR /src/pyrsia
-RUN PATH="$HOME/.cargo/bin:$PATH" RUST_LOG=debug cargo build --package=pyrsia_node
+RUN PATH="$HOME/.cargo/bin:$PATH" RUST_LOG=debug cargo build -q --package=pyrsia_node


### PR DESCRIPTION
- one test disabled until 0.3 ([pyrsia_node_maven_build_service.bats](https://github.com/pyrsia/pyrsia-integration-tests/commit/e2465e15886845e4a772a4d83bc706a13367153d))
- refactoring and the logs adjustments