### PR TITLE
Refine: Review triggers for Actions and make Git related variables work

### DIFF
--- a/.github/workflows/run-bats-tests.yml
+++ b/.github/workflows/run-bats-tests.yml
@@ -7,8 +7,7 @@ on:
   pull_request:
     types:
       - opened
-      - closed
-      - synchronized
+      - synchronize
       - reopened
       - ready_for_review
 

--- a/bats/tests/common-setup.bash
+++ b/bats/tests/common-setup.bash
@@ -21,8 +21,12 @@ _common_setup_file() {
   fi
   # clone or update the sources
   if [ -d $PYRSIA_TEMP_DIR/.git ]; then
-    git --git-dir=$PYRSIA_TEMP_DIR/.git fetch
-    git --git-dir=$PYRSIA_TEMP_DIR/.git --work-tree=$PYRSIA_TEMP_DIR merge origin/$GIT_BRANCH
+    export GIT_DIR=$PYRSIA_TEMP_DIR/.git
+    export GIT_WORK_TREE=$PYRSIA_TEMP_DIR
+    git remote set-url origin $GIT_REPO
+    git fetch
+    git switch $GIT_BRANCH
+    git merge origin/$GIT_BRANCH
   else
     mkdir -p $PYRSIA_TEMP_DIR
     git clone --branch $GIT_BRANCH $GIT_REPO $PYRSIA_TEMP_DIR


### PR DESCRIPTION
- Removed and fixed some triggers for GitHub Actions
- Made `$GIT_REPO` and `$GIT_BRANCH` work when users want to change the repo and branch at their local environment.