### PR TITLE
Add a logger to the integration tests to support basic log levels - INFO, DEBUG, ERROR #1299  and Add "Troubleshooting" section to the integration tests README #1293 

### DIFF
--- a/bats/lib/logger/load.bash
+++ b/bats/lib/logger/load.bash
@@ -1,0 +1,3 @@
+# shellcheck disable=1090
+source "$(dirname "${BASH_SOURCE[0]}")/logger.bash"
+

--- a/bats/lib/logger/logger.bash
+++ b/bats/lib/logger/logger.bash
@@ -31,10 +31,11 @@ get_log_level() {
 }
 
 log() {
- # log level
- local log_level_priority=$(get_log_level $TEST_LOG_LEVEL)
+ local log_level_priority
+ log_level_priority=$(get_log_level $TEST_LOG_LEVEL)
  local message_level=$1
- local message_priority=$(get_log_level $message_level)
+ local message_priority
+ message_priority=$(get_log_level $message_level)
  local message=$2
 
  if (( message_priority < 0 )) ; then

--- a/bats/lib/logger/logger.bash
+++ b/bats/lib/logger/logger.bash
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# If the log level is not provided then TEST_LOG_LEVEL is set to INFO
+if [ -z "$TEST_LOG_LEVEL" ]; then
+  TEST_LOG_LEVEL="INFO";
+fi
+# This function translate the log level name to int priority, we wouldn't need this if we could use newer bash with proper arrays (-A)
+get_log_level() {
+  local priority
+
+  case $1 in
+
+      INFO)
+        priority=0
+        ;;
+
+      DEBUG)
+        priority=1
+        ;;
+
+      ERROR)
+        priority=2
+        ;;
+
+      *)
+        priority=-1
+        ;;
+    esac
+
+    echo $priority
+}
+
+log() {
+ # log level
+ local log_level_priority=$(get_log_level $TEST_LOG_LEVEL)
+ local message_level=$1
+ local message_priority=$(get_log_level $message_level)
+ local message=$2
+
+ if (( message_priority < 0 )) ; then
+    echo "The log level '${message_level}' is incorrect, supported log levels: INFO, DEBUG, ERROR."
+    exit 1
+  fi
+
+  # Check if message should be printed based on the message level
+  if (( log_level_priority >= message_priority )); then
+    # print the log message
+    echo "${message_level} : ${message}" >&3
+  fi
+}

--- a/bats/tests/common-setup.bash
+++ b/bats/tests/common-setup.bash
@@ -5,6 +5,8 @@ PYRSIA_TEMP_DIR=/tmp/pyrsia_tests/pyrsia
 # the pyrsia binaries
 PYRSIA_TARGET_DIR=$PYRSIA_TEMP_DIR/target/release
 
+load '../lib/logger/load'
+
 _common_setup() {
   # load the bats "extensions"
   load '../lib/test_helper/bats-support/load'
@@ -60,7 +62,8 @@ _common_teardown_file() {
   echo " " >&3
   CLEAN_UP_TEST_ENVIRONMENT=true
   # print docker logs
-  #docker-compose -f "$DOCKER_COMPOSE_PATH" logs >&3
+  local docker_logs=$(docker-compose -f "$DOCKER_COMPOSE_PATH" logs)
+  log DEBUG "${docker_logs}"
   if [ "$CLEAN_UP_TEST_ENVIRONMENT" = true ]; then
     echo "Tearing down the tests environment..." >&3
     echo "Cleaning up the docker images and containers..."  >&3
@@ -84,6 +87,7 @@ _set_node_as_authorized() {
     # obtain the peer id form the node
     PEER_ID=$(curl -s http://"$node_hostname"/status | jq -r ".peer_id")
     if [ -n "$PEER_ID" ] && [ "$PEER_ID" != "null" ]; then
+      log DEBUG "Node added to authorized nodes - peer ID - ${PEER_ID}"
       # the peer id obtained, break
       break
     fi

--- a/bats/tests/common-setup.bash
+++ b/bats/tests/common-setup.bash
@@ -64,7 +64,9 @@ _common_teardown_file() {
   # print docker logs
   local docker_logs
   docker_logs=$(docker-compose -f "$DOCKER_COMPOSE_PATH" logs)
+  log DEBUG "================== START Docker logs for ${DOCKER_COMPOSE_PATH} =================="
   log DEBUG "${docker_logs}"
+  log DEBUG "================== END Docker logs for ${DOCKER_COMPOSE_PATH} =================="
   if [ "$CLEAN_UP_TEST_ENVIRONMENT" = true ]; then
     echo "Tearing down the tests environment..." >&3
     echo "Cleaning up the docker images and containers..."  >&3

--- a/bats/tests/common-setup.bash
+++ b/bats/tests/common-setup.bash
@@ -62,7 +62,8 @@ _common_teardown_file() {
   echo " " >&3
   CLEAN_UP_TEST_ENVIRONMENT=true
   # print docker logs
-  local docker_logs=$(docker-compose -f "$DOCKER_COMPOSE_PATH" logs)
+  local docker_logs
+  docker_logs=$(docker-compose -f "$DOCKER_COMPOSE_PATH" logs)
   log DEBUG "${docker_logs}"
   if [ "$CLEAN_UP_TEST_ENVIRONMENT" = true ]; then
     echo "Tearing down the tests environment..." >&3

--- a/readme.md
+++ b/readme.md
@@ -24,12 +24,11 @@ Fetch the repository with the dependencies (the submodules are necessary to succ
 
 ```sh
 git clone --recurse-submodules https://github.com/pyrsia/pyrsia-integration-tests.git
-
 ```
 
 In case you forgot to set `--recurse-submodules` during `clone` you can run the following command for the same effect:
 
-```
+```sh
 git submodule update --init
 ```
 
@@ -77,3 +76,41 @@ The docker containers and images created by the tests framework are removed when
 The docker images and containers have to be removed manually if CLEAN_UP_TEST_ENVIRONMENT=false. The Pyrsia integration
 tests also create the temp directory `/tmp/pyrsia_tests`which is not removed by the tests framework and if necessary has to be removed
 manually.
+
+## Troubleshooting
+
+In case of any problems with the tests environment reset the enviroment as follow:
+1) Remove all docker images and containers:
+   ```sh
+      docker system prune --all
+   ```
+2) Remove the integration tests temp directory:
+   ```sh
+      rm -rf /tmp/pyrsia_tests/
+   ```
+
+## Tests logger
+
+Supported logging levels:
+- INFO (default)
+- DEBUG
+- ERROR
+
+How to use logger in the tests:
+
+```sh
+  # load the test from the library
+  load '../lib/logger/load'
+  
+  # print logging messages
+  log INFO  "Info test message!"
+  log DEBUG "Debug test message!"
+  log ERROR "Error test message!"
+```
+
+How to start tests with different logging level (e.g DEBUG):
+
+```sh
+  TEST_LOG_LEVEL=DEBUG REPO_DIR=<path to your integration tests repo> $REPO_DIR/bats/run_tests.sh
+```
+


### PR DESCRIPTION
Two tickets are covered in this PR:
1) Add a logger to the integration tests to support basic log levels - INFO, DEBUG, ERROR (#1299)
2) Add "Troubleshooting" section to the integration tests README (#1293) 
3) Bonus - if the tests are started with `TEST_LOG_LEVEL=DEBUG` then the docker logs are printed when a test is "destroyed". 