### PR TITLE
install protobuf-compiler debian package

### DIFF
--- a/bats/tests/resources/docker/Dockerfile
+++ b/bats/tests/resources/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV DEV_MODE=onapt
 ARG GIT_BRANCH
 ARG GIT_REPO
 RUN apt-get update && apt-get install -y -q
-RUN apt-get install build-essential libssl-dev cmake pkg-config jq openjdk-11-jdk maven jq -y -q
+RUN apt-get install build-essential libssl-dev cmake pkg-config jq openjdk-11-jdk maven jq protobuf-compiler -y -q
 RUN git clone https://github.com/tiainen/pyrsia_build_pipeline_prototype.git
 WORKDIR /src/pyrsia_build_pipeline_prototype
 RUN PATH="$HOME/.cargo/bin:$PATH" RUST_LOG=debug cargo build -q --workspace


### PR DESCRIPTION
Fixes #19 by installing the `protobuf-compiler` debian package in the docker image.