### PR TITLE
Fix failed tests (partially): Ignore case if letters are created by libraries

### DIFF
--- a/bats/tests/pyrsia_cli.bats
+++ b/bats/tests/pyrsia_cli.bats
@@ -28,19 +28,21 @@ teardown() {
 }
 
 @test "Testing 'pyrsia help' CLI, check if the help is shown." {
+  # ignore case in this @test
+  shopt -s nocasematch
   # run pyrsia help
   run "$PYRSIA_CLI" help
   # check if pyrsia help is shown
-  assert_output --partial 'USAGE:'
-  assert_output --partial 'OPTIONS:'
-  assert_output --partial 'SUBCOMMANDS:'
+  assert_output --partial 'Usage:'
+  assert_output --partial 'Commands:'
+  assert_output --partial 'Options:'
 
   # run pyrsia help
   run "$PYRSIA_CLI" -h
   # check if pyrsia help is shown
-  assert_output --partial 'USAGE:'
-  assert_output --partial 'OPTIONS:'
-  assert_output --partial 'SUBCOMMANDS:'
+  assert_output --partial 'Usage:'
+  assert_output --partial 'Commands:'
+  assert_output --partial 'Options:'
 }
 
 @test "Testing 'pyrsia ping' CLI, check if the node is up and reachable." {


### PR DESCRIPTION
## Description

This problem is found because regular executions of integration tests failed.
GitHub Actions log: https://github.com/pyrsia/pyrsia-integration-tests/actions/runs/3630701057
Note: There is another failed test that is not fixed by this PR (Investigating & asking the team).

CLI outputs changed like from `USAGE` to `usage`, which is caused by Clap crate updates (Seems related to: https://github.com/clap-rs/clap/pull/4123, https://github.com/clap-rs/clap/pull/4155).
Its codes are outside of Pyrsia and not controllable, so this PR added settings to ignore case.

### After Clap update (Causing tests failure)
```
pyrsia_cli 0.2.1 (c65228f876b76de660660d259ea561a194c555db)
Decentralized Package Network

USAGE:
    pyrsia [SUBCOMMAND]

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    authorize      Add an authorized node
    build -b       Request a new build
    config -c      Configure Pyrsia
    inspect-log    Show transparency logs
    list -l        Show a list of connected peers
    ping           Pings configured pyrsia node
    status -s      Show information about the Pyrsia node
    help           Print this message or the help of the given subcommand(s)
```
### Before Clap update
```
Decentralized Package Network

Usage: pyrsia [COMMAND]

Commands:
  authorize    Add an authorized node
  build, -b    Request a new build
  config, -c   Configure Pyrsia
  inspect-log  Show transparency logs
  list, -l     Show a list of connected peers
  ping         Pings configured pyrsia node
  status, -s   Show information about the Pyrsia node
  help         Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help information
  -V, --version  Print version information
```