### PR TITLE
Pin rust compiler version to Cargo.toml

### DIFF
--- a/.github/workflows/run-bats-tests.yml
+++ b/.github/workflows/run-bats-tests.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Get Pyrsia Cargo.toml for Rust Version
+        run: wget https://raw.githubusercontent.com/pyrsia/pyrsia/main/Cargo.toml
+
       - uses: pyrsia/rust-toolchain@v1
 
       # Use sscache store in GitHub cache

--- a/.github/workflows/run-bats-tests.yml
+++ b/.github/workflows/run-bats-tests.yml
@@ -24,14 +24,12 @@ jobs:
       RUSTC_WRAPPER: /home/runner/.cargo/bin/sccache
       CARGO_INCREMENTAL: 0
     steps:
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           submodules: true
+
+      - uses: pyrsia/rust-toolchain@v1
 
       # Use sscache store in GitHub cache
       - uses: actions/cache@v3
@@ -44,9 +42,6 @@ jobs:
           .github/workflows/sccache-linux.sh
           sccache --start-server
           sccache --show-stats
-
-      - name: Install dependencies
-        run: sudo apt-get install protobuf-compiler -y -q
 
       - name: Execute Test Cases
         run: |

--- a/bats/tests/resources/docker/Dockerfile
+++ b/bats/tests/resources/docker/Dockerfile
@@ -1,19 +1,28 @@
 # syntax=docker/dockerfile:1.4.1
 
-FROM rust:1.62-buster AS node_with_build_service
+FROM rust:1.64-buster AS node_with_build_service
 WORKDIR /src
 ENV RUST_BACKTRACE=1
 ENV DEV_MODE=onapt
 ARG GIT_BRANCH
 ARG GIT_REPO
 RUN apt-get update && apt-get install -y -q
-RUN apt-get install build-essential libssl-dev cmake pkg-config jq openjdk-11-jdk maven jq protobuf-compiler -y -q
-RUN git clone https://github.com/tiainen/pyrsia_build_pipeline_prototype.git
-WORKDIR /src/pyrsia_build_pipeline_prototype
-RUN PATH="$HOME/.cargo/bin:$PATH" RUST_LOG=debug cargo build -q --workspace
+RUN apt-get install build-essential libssl-dev cmake pkg-config jq openjdk-11-jdk maven protobuf-compiler -y -q
+
 WORKDIR /src
 COPY entrypoint_bootstrap_node.sh entrypoint_no_bootstrap_node.sh entrypoint_auth_node.sh ./
 RUN chmod +x ./*.sh
 RUN git clone --branch $GIT_BRANCH $GIT_REPO
 WORKDIR /src/pyrsia
-RUN PATH="$HOME/.cargo/bin:$PATH" RUST_LOG=debug cargo build -q --package=pyrsia_node
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -; \
+    apt-get install -y -q nodejs; \
+    npm i -g toml-cli; \
+    rustup default $(cat Cargo.toml | toml | jq -r 'try(.package."rust-version") // "stable"')
+
+RUN PATH="$PATH:$HOME/.cargo/bin" RUST_LOG=debug cargo build -q --package=pyrsia_node
+
+WORKDIR /src
+RUN git clone https://github.com/tiainen/pyrsia_build_pipeline_prototype.git
+
+WORKDIR /src/pyrsia_build_pipeline_prototype
+RUN PATH="$PATH:$HOME/.cargo/bin" RUST_LOG=debug cargo build -q --workspace


### PR DESCRIPTION
Reworked the Dockkerfile to pull the Rust version from the Cargo.toml.  Also, updated the GH Action to use the Pyrsia Rust Toolchain action.

Run docker builds local and they ran successfully.

Fixes pyrsia/pyrsia#1374