### PR TITLE
Implement Slack notifications

### DIFF
--- a/.github/workflows/run-bats-tests.yml
+++ b/.github/workflows/run-bats-tests.yml
@@ -10,6 +10,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - closed
 
 env:
   CARGO_TERM_COLOR: always
@@ -49,3 +50,38 @@ jobs:
       - name: Execute Test Cases
         run: |
           REPO_DIR="./" CLEAN_UP_TEST_ENVIRONMENT=true ./bats/lib/bats/bin/bats ./bats/tests
+
+      # Send the result to Slack when a PR is merged and tests were executed regularly
+      - name: Notify success
+        if: ${{ success() && contains(fromJson('["push", "schedule"]'), github.event_name) }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ secrets.CHANNEL_ID_FOR_MESSAGES }}
+          # If https://github.com/slackapi/slack-github-action/issues/84 is fixed, payload.json can be shared among the following two steps (DRY).
+          payload: |
+            {
+              "text": "Integration tests finished successfully.",
+              "attachments": [{
+              "title": ":white_check_mark: ${{ github.workflow }} #${{ github.run_number }}",
+              "title_link": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "color": "#36a64f"
+              }]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      - name: Notify failure
+        if: ${{ failure() && contains(fromJson('["push", "schedule"]'), github.event_name) }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ secrets.CHANNEL_ID_FOR_ALERTS }}
+          payload: |
+            {
+              "text": "Integration tests failed. Check the following workflow and fix it.",
+              "attachments": [{
+              "title": ":x: ${{ github.workflow }} #${{ github.run_number }}",
+              "title_link": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "color": "#ff0000"
+              }]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
https://github.com/pyrsia/pyrsia/issues/1373
Set up Slack notifications.

- Notifications are sent to Slack **only when PRs are merged or regular executions run** (not when PRs got open or ready). This is because tests can fail frequently while PRs are open, which would be okay as people should notice until merges. Also, it would make unnecessary alerts.
- Failure notifications go to `#pyrsia_alerts`, and success ones will be sent to `#pyrsia_notifications`.

[GitHub integration for Slack](https://github.com/integrations/slack#actions-workflow-notifications) was one of options to achieve the goal, but it does not allow us to change channels according to the result.
If this integration supports failure only alerts, it would be perfect. The feature is already requested - https://github.com/integrations/slack/issues/1563.

## Set up needed

Before merging this PR, a Slack app is to be configured. In addition, we should add `CHANNEL_ID_FOR_MESSAGES`, `CHANNEL_ID_FOR_ALERTS`, `SLACK_BOT_TOKEN` to GitHub Actions secrets.

## Screenshots
(Tested using @ihcomega56 's personal repo and channels.)
The text `Integration Test #xx` is a link to an action workflow.

![image](https://user-images.githubusercontent.com/8938191/207257934-fb94dff1-e3c7-4c6d-99ec-c3a546b60d35.png)
![image](https://user-images.githubusercontent.com/8938191/207257996-9242870a-3625-4b74-9368-4ab20226fe30.png)
