### PR TITLE
Run shell lint check whenever tests are updated

### DIFF
--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Now the Lint workflow runs only PRs are open.
Added triggers `synchronize`, `reopened`, and `ready_for_review` to make it run every time after integration tests are updated.