### PR TITLE
Upgrade rust-toolchain to v2

### DIFF
--- a/.github/workflows/run-bats-tests.yml
+++ b/.github/workflows/run-bats-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get Pyrsia Cargo.toml for Rust Version
         run: wget https://raw.githubusercontent.com/pyrsia/pyrsia/main/Cargo.toml
 
-      - uses: pyrsia/rust-toolchain@v1
+      - uses: pyrsia/rust-toolchain@v2
 
       # Use sscache store in GitHub cache
       - uses: actions/cache@v3


### PR DESCRIPTION
This PR fixes https://github.com/pyrsia/pyrsia/issues/1300
All warnings of GitHub Actions are solved by this change.